### PR TITLE
feat: integrate modern font and pastel icons

### DIFF
--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import { BarChart3 } from 'lucide-react';
 
 /**
  * Contenedor animado reutilizable para cualquier gráfico o KPI.
@@ -16,7 +17,10 @@ export default function ChartCard({ title, children }) {
     >
       <div className="bg-white/20 backdrop-blur-xl border border-white/30 shadow-md rounded-[40px] shadow-inner drop-shadow w-full h-full overflow-hidden">
         <div className="p-8 w-full h-full flex flex-col gap-4">
-          <h3 className="text-lg font-semibold text-white">{title}</h3>
+          <h3 className="flex items-center gap-2 text-2xl font-modern font-semibold text-white">
+            <BarChart3 className="w-6 h-6 text-blue-300" />
+            {title}
+          </h3>
           {/* El área de contenido ocupa todo el espacio restante */}
           <div className="flex-1">{children}</div>
         </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { DataContext } from '../context/DataContext';
+import { LayoutDashboard, Filter } from 'lucide-react';
 
 /**
  * Encabezado del dashboard. Muestra el título y el selector de filtro.
@@ -7,18 +8,24 @@ import { DataContext } from '../context/DataContext';
 export default function Header() {
   const { filter, setFilter } = useContext(DataContext);
   return (
-    <div className="flex items-center justify-between mb-2">
-      <h1 className="text-2xl font-bold text-white">Dashboard</h1>
-      <select
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-        className="bg-white/20 backdrop-blur text-white p-2 rounded-lg"
-      >
-        <option value="All">Todos</option>
-        <option value="Revenue">Revenue</option>
-        <option value="Sales">Sales</option>
-        <option value="Visitors">Visitors</option>
-      </select>
+    <div className="flex items-center justify-between mb-4">
+      <h1 className="flex items-center gap-2 text-4xl font-modern font-bold text-white">
+        <LayoutDashboard className="w-6 h-6 text-pink-300" />
+        Dashboard
+      </h1>
+      <div className="flex items-center gap-2">
+        <Filter className="w-6 h-6 text-pink-300" />
+        <select
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="bg-white/20 backdrop-blur text-white p-2 rounded-lg font-modern text-lg"
+        >
+          <option value="All">Todos</option>
+          <option value="Revenue">Revenue</option>
+          <option value="Sales">Sales</option>
+          <option value="Visitors">Visitors</option>
+        </select>
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,16 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 module.exports = {
   content: [
     "./public/index.html",
     "./src/**/*.{js,jsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        modern: ['"Poppins"', ...defaultTheme.fontFamily.sans],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- import Poppins from Google Fonts and extend Tailwind font family
- restyle header and chart card with larger typography and pastel Lucide icons

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893e66555c88331a6e6eec7ad8844ff