### PR TITLE
Enable soft shadows and add card drop shadows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { Canvas } from '@react-three/fiber';
-import { RoundedBox, Environment } from '@react-three/drei';
+import { RoundedBox, Environment, softShadows } from '@react-three/drei';
 import { motion } from 'framer-motion';
 import DashboardOverlay from './components/DashboardOverlay';
 import Header from './components/Header';
 import FilterControls from './components/FilterControls';
+
+// Enable soft shadows across the scene
+softShadows();
 
 // Variants for a subtle wobble animation on the overlay panel.
 const wobble = {
@@ -23,9 +26,9 @@ export default function App() {
   return (
     <div className="h-screen w-screen relative overflow-hidden">
       {/* 3D Canvas background using react-three-fiber */}
-      <Canvas camera={{ position: [0, 0, 5], fov: 50 }}>
+      <Canvas shadows camera={{ position: [0, 0, 5], fov: 50 }}>
         <ambientLight intensity={0.5} />
-        <directionalLight intensity={1} position={[5, 5, 5]} />
+        <directionalLight castShadow intensity={1} position={[5, 5, 5]} />
         <Environment
           files="https://raw.githubusercontent.com/pmndrs/drei-assets/master/hdri/studio_small_09_1k.hdr"
           intensity={0.2}
@@ -33,6 +36,8 @@ export default function App() {
         />
         {/* Rounded glass frame surrounding the dashboard */}
         <RoundedBox
+          castShadow
+          receiveShadow
           args={[5, 3, 0.1]}
           radius={0.05}
           smoothness={4}

--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -15,9 +15,9 @@ export default function ChartCard({ title, children }) {
       animate={{ opacity: 1, y: 0 }}
       transition={transition}
       whileHover={{ y: -4, transition }}
-      className="w-full h-full"
+      className="w-full h-full drop-shadow-lg"
     >
-      <div className="bg-white/20 backdrop-blur-xl border border-white/30 shadow-md rounded-[40px] shadow-inner drop-shadow w-full h-full overflow-hidden">
+      <div className="bg-white/20 backdrop-blur-xl border border-white/30 shadow-md rounded-[40px] shadow-inner w-full h-full overflow-hidden">
         <div className="p-8 w-full h-full flex flex-col gap-4">
           <h3 className="flex items-center gap-2 text-2xl font-modern font-semibold text-white">
             <BarChart3 className="w-6 h-6 text-blue-300" />


### PR DESCRIPTION
## Summary
- activate soft shadows in Three.js scene and enable shadow casting and receiving
- add Tailwind drop shadows to dashboard cards for better background separation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893eff392b883318488c746e20d5bf0