### PR TITLE
feat: responsive dashboard grid

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,7 +64,9 @@ export default function App() {
         {/* Date range controls */}
         <FilterControls />
         {/* Dashboard grid; pointer-events-auto allows interaction */}
-        <div className="grid grid-cols-3 grid-rows-2 gap-4 mt-4 h-full pointer-events-auto">
+        <div
+          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 grid-rows-2 gap-4 md:gap-6 lg:gap-8 mt-4 h-full pointer-events-auto"
+        >
           <DashboardOverlay />
         </div>
       </motion.div>

--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -17,8 +17,8 @@ export default function ChartCard({ title, children }) {
       whileHover={{ y: -4, transition }}
       className="w-full h-full drop-shadow-lg"
     >
-      <div className="bg-white/20 backdrop-blur-xl border border-white/30 shadow-md rounded-[40px] shadow-inner w-full h-full overflow-hidden">
-        <div className="p-8 w-full h-full flex flex-col gap-4">
+      <div className="bg-white/20 backdrop-blur-xl border border-white/30 shadow-md rounded-2xl sm:rounded-3xl lg:rounded-[40px] shadow-inner w-full h-full overflow-hidden">
+        <div className="p-4 sm:p-6 lg:p-8 w-full h-full flex flex-col gap-4 sm:gap-6 lg:gap-8">
           <h3 className="flex items-center gap-2 text-2xl font-modern font-semibold text-white">
             <BarChart3 className="w-6 h-6 text-blue-300" />
             {title}


### PR DESCRIPTION
## Summary
- make dashboard grid responsive with breakpoint-aware columns and gaps
- ensure chart cards retain rounded corners and consistent spacing across breakpoints

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893f416bf1083319e93b78db481ef4f