### PR TITLE
chore: upgrade three for stats-gl compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-scripts": "5.0.1",
         "recharts": "^2.5.0",
         "tailwindcss": "^3.3.5",
-        "three": "^0.153.0"
+        "three": "^0.170.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.4",
@@ -17285,12 +17285,6 @@
         "three": "*"
       }
     },
-    "node_modules/stats-gl/node_modules/three": {
-      "version": "0.170.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
-      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
-      "license": "MIT"
-    },
     "node_modules/stats.js": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
@@ -18211,9 +18205,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg==",
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
       "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-scripts": "5.0.1",
     "recharts": "^2.5.0",
     "tailwindcss": "^3.3.5",
-    "three": "^0.153.0"
+    "three": "^0.170.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",


### PR DESCRIPTION
## Summary
- bump three to ^0.170.0 to match stats-gl requirements

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68940f9c25c48331a8f0062a7dcf447a