### PR TITLE
Fix GitHub Pages deploy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ npm run build
 ```
 
 ### Deployment
-The project includes a GitHub Pages deployment script:
+The project includes a GitHub Pages deployment script that publishes the `build` folder to
+the `gh-pages` branch of [`gatdeguin/UI_2`](https://github.com/gatdeguin/UI_2) using an
+explicit repository URL. This allows deployment even if no `origin` remote is configured.
 ```bash
 npm run deploy
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "glass-dashboard",
   "version": "1.0.0",
   "private": true,
-  "homepage": ".",
+  "homepage": "https://gatdeguin.github.io/UI_2",
   "dependencies": {
     "@react-three/drei": "^9.0.0",
     "@react-three/fiber": "^8.13.1",
@@ -29,7 +29,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -d build --repo https://github.com/gatdeguin/UI_2.git"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
- set package homepage to project’s GitHub Pages URL
- configure gh-pages deploy script with explicit repository
- document deploy script behavior in README

## Testing
- `npm test -- --watchAll=false`
- `npm run deploy` *(prompts for GitHub credentials; build succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_68949ca03258833187e6265bba1dddd1